### PR TITLE
Add a separate Reporter for Detekt

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/reports/Reporter.java
+++ b/src/main/java/se/bjurr/violations/lib/reports/Reporter.java
@@ -49,6 +49,7 @@ public enum Reporter {
   CPPCHECK(new CPPCheckParser()), //
   CPPLINT(new CppLintParser()), //
   CSSLINT(new CSSLintParser()), //
+  DETEKT(new CheckStyleParser()), //
   FINDBUGS(new FindbugsParser()), //
   FLAKE8(new Flake8Parser()), //
   FXCOP(new FxCopParser()), //


### PR DESCRIPTION
While `CHECKSTYLE` works, it would be much more useful to know that a specific issue came from Detekt, and not Checkstyle.