### PR TITLE
Added handling for empty IssueType Description attributes for Resharper

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/parsers/ResharperParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/ResharperParser.java
@@ -6,6 +6,7 @@ import static se.bjurr.violations.lib.model.SEVERITY.WARN;
 import static se.bjurr.violations.lib.model.Violation.violationBuilder;
 import static se.bjurr.violations.lib.parsers.ViolationParserUtils.findIntegerAttribute;
 import static se.bjurr.violations.lib.parsers.ViolationParserUtils.getAttribute;
+import static se.bjurr.violations.lib.parsers.ViolationParserUtils.findAttribute;
 import static se.bjurr.violations.lib.parsers.ViolationParserUtils.getChunks;
 import static se.bjurr.violations.lib.reports.Parser.RESHARPER;
 
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import se.bjurr.violations.lib.model.SEVERITY;
 import se.bjurr.violations.lib.model.Violation;
+import se.bjurr.violations.lib.util.Optional;
 
 public class ResharperParser implements ViolationsParser {
 
@@ -27,7 +29,8 @@ public class ResharperParser implements ViolationsParser {
       Map<String, String> issueType = new HashMap<>();
       String id = getAttribute(issueTypesChunk, "Id");
       issueType.put("category", getAttribute(issueTypesChunk, "Category"));
-      issueType.put("description", getAttribute(issueTypesChunk, "Description"));
+      Optional<String> description = findAttribute(issueTypesChunk, "Description");
+      issueType.put("description", description.isPresent() ? description.get() : id); //use the description if it's present, otherwise default to the id
       issueType.put("severity", getAttribute(issueTypesChunk, "Severity"));
       issueTypesPerTypeId.put(id, issueType);
     }

--- a/src/test/java/se/bjurr/violations/lib/ResharperTest.java
+++ b/src/test/java/se/bjurr/violations/lib/ResharperTest.java
@@ -3,6 +3,7 @@ package se.bjurr.violations.lib;
 import static org.assertj.core.api.Assertions.assertThat;
 import static se.bjurr.violations.lib.TestUtils.getRootFolder;
 import static se.bjurr.violations.lib.ViolationsReporterApi.violationsReporterApi;
+import static se.bjurr.violations.lib.model.SEVERITY.ERROR;
 import static se.bjurr.violations.lib.model.SEVERITY.INFO;
 import static se.bjurr.violations.lib.model.SEVERITY.WARN;
 import static se.bjurr.violations.lib.reports.Parser.RESHARPER;
@@ -25,7 +26,7 @@ public class ResharperTest {
             .violations();
 
     assertThat(actual) //
-        .hasSize(3);
+        .hasSize(4);
 
     assertThat(actual.get(0).getReporter()) //
         .isEqualTo(RESHARPER.name());
@@ -59,5 +60,14 @@ public class ResharperTest {
         .isEqualTo("MyLibrary/Properties/AssemblyInfo.cs");
     assertThat(actual.get(2).getSeverity()) //
         .isEqualTo(WARN);
+
+    assertThat(actual.get(3).getMessage()) //
+        .isEqualTo("Cannot resolve symbol 'GetError'. C# Compiler Errors. CSharpErrors");
+    assertThat(actual.get(3).getRule().get()) //
+        .isEqualTo("CSharpErrors");
+    assertThat(actual.get(3).getFile()) //
+        .isEqualTo("MyLibrary/Class1.cs");
+    assertThat(actual.get(3).getSeverity()) //
+        .isEqualTo(ERROR);
   }
 }

--- a/src/test/resources/resharper/main.xml
+++ b/src/test/resources/resharper/main.xml
@@ -10,12 +10,14 @@
   <IssueTypes>
     <IssueType Id="JoinDeclarationAndInitializer" Category="Common Practices and Code Improvements" Description="Join local variable declaration and assignment" Severity="SUGGESTION" />
     <IssueType Id="RedundantUsingDirective" Category="Redundancies in Code" Description="Redundant using directive" Severity="WARNING" WikiUrl="http://confluence.jetbrains.net/display/ReSharper/Redundant+using+directive" />
+    <IssueType Id="CSharpErrors" Category="C# Compiler Errors" Description="" Severity="ERROR"/>
   </IssueTypes>
   <Issues>
     <Project Name="MyLibrary">
       <Issue TypeId="RedundantUsingDirective" File="MyLibrary\Class1.cs" Offset="0-13" Message="Using directive is not required by the code and can be safely removed" />
       <Issue TypeId="JoinDeclarationAndInitializer" File="MyLibrary\Class1.cs" Offset="138-144" Line="9" Message="Join declaration and assignment" />
       <Issue TypeId="RedundantUsingDirective" File="MyLibrary\Properties\AssemblyInfo.cs" Offset="26-64" Line="2" Message="Using directive is not required by the code and can be safely removed" />
+      <Issue TypeId="CSharpErrors" File="MyLibrary\Class1.cs" Offset="1-10" Line="10" Message="Cannot resolve symbol 'GetError'" />
     </Project>
   </Issues>
 </Report>


### PR DESCRIPTION
Thanks for this code, it's a lifesaver for my builds! I have run into an issue when Resharper InspectCode outputs a compiler error (missing library, etc.) it has an empty description in the XML. This was causing an exception which I found by turning on Jenkins logs in your plugin. This should correct it so that this case is handled.