### PR TITLE
Parameterize the max line length for the report table.

### DIFF
--- a/src/test/java/se/bjurr/violations/lib/ViolationsReporterApiTest.java
+++ b/src/test/java/se/bjurr/violations/lib/ViolationsReporterApiTest.java
@@ -1,5 +1,6 @@
 package se.bjurr.violations.lib;
 
+import static org.junit.Assert.assertTrue;
 import static se.bjurr.violations.lib.TestUtils.getRootFolder;
 import static se.bjurr.violations.lib.ViolationsApi.violationsApi;
 import static se.bjurr.violations.lib.ViolationsReporterApi.violationsReporterApi;
@@ -126,5 +127,47 @@ public class ViolationsReporterApiTest {
             .getReport(VERBOSE);
 
     LOG.info("\n" + report);
+  }
+
+  @Test
+  public void testCompactWithLineLength() {
+    final String report =
+        violationsReporterApi() //
+            .withViolations(accumulatedViolations) //
+            .withMaxLineLength(100) //
+            .getReport(COMPACT);
+
+    LOG.info("\n" + report);
+    for (String line : report.split("\n")) {
+      assertTrue("Got: " + line.length(), line.length() <= 100);
+    }
+  }
+
+  @Test
+  public void testPerFileCompactWithLineLength() {
+    final String report =
+        violationsReporterApi() //
+            .withViolations(accumulatedViolations) //
+            .withMaxLineLength(100) //
+            .getReport(PER_FILE_COMPACT);
+
+    LOG.info("\n" + report);
+    for (String line : report.split("\n")) {
+      assertTrue("Got: " + line.length(), line.length() <= 100);
+    }
+  }
+
+  @Test
+  public void testVerboseWithLineLength() {
+    final String report =
+        violationsReporterApi() //
+            .withViolations(accumulatedViolations) //
+            .withMaxLineLength(100) //
+            .getReport(VERBOSE);
+
+    LOG.info("\n" + report);
+    for (String line : report.split("\n")) {
+      assertTrue("Got: " + line.length(), line.length() <= 100);
+    }
   }
 }


### PR DESCRIPTION
The motivation is to optionally provide better formatting when printing to output that has strict line limits. In my case I'm particularly interested in the output in travis-ci's log. I've attached a screenshot that shows the current behavior when Travis' log line length is exceeded. 
<img width="1059" alt="screen shot 2018-01-10 at 6 27 22 pm" src="https://user-images.githubusercontent.com/1627211/34805702-46efc54a-f634-11e7-8ef3-b503bea77e8d.png">

This could be more intelligent, but for now this just restricts the length of the message column. I've retained the existing behavior of allowing up to 100 characters in the message column if no line limit is specified.