### PR TITLE
Added ScalaStyle reporter with CheckStyle parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ A number of **parsers** have been implemented. Some **parsers** can parse output
 | [_XMLLint_](http://xmlsoft.org/xmllint.html)                                          | `XMLLINT`            | 
 | [_YAMLLint_](https://yamllint.readthedocs.io/en/stable/index.html)                    | `YAMLLINT`           | With `-f parsable`
 | [_ZPTLint_](https://pypi.python.org/pypi/zptlint)                                     | `ZPTLINT`            |
+| [_Scalastyle_](http://www.scalastyle.org/)                                            | `CHECKSTYLE`         |
+
 
 Missing a format? Open an issue [here](https://github.com/tomasbjerre/violations-lib/issues)!
 

--- a/src/main/java/se/bjurr/violations/lib/reports/Reporter.java
+++ b/src/main/java/se/bjurr/violations/lib/reports/Reporter.java
@@ -129,7 +129,8 @@ public enum Reporter {
       Parser.YAMLLINT,
       "https://yamllint.readthedocs.io/en/stable/index.html",
       "With `-f parsable`"),
-  ZPTLINT("ZPTLint", Parser.ZPTLINT, "https://pypi.python.org/pypi/zptlint", "");
+  ZPTLINT("ZPTLint", Parser.ZPTLINT, "https://pypi.python.org/pypi/zptlint", ""),
+  SCALASTYLE("ScalaStyle", Parser.CHECKSTYLE, "http://www.scalastyle.org/", "");
 
   private final String url;
   private final String name;

--- a/src/main/java/se/bjurr/violations/lib/reports/Reporter.java
+++ b/src/main/java/se/bjurr/violations/lib/reports/Reporter.java
@@ -130,7 +130,7 @@ public enum Reporter {
       "https://yamllint.readthedocs.io/en/stable/index.html",
       "With `-f parsable`"),
   ZPTLINT("ZPTLint", Parser.ZPTLINT, "https://pypi.python.org/pypi/zptlint", ""),
-  SCALASTYLE("ScalaStyle", Parser.CHECKSTYLE, "http://www.scalastyle.org/", "");
+  SCALASTYLE("Scalastyle", Parser.CHECKSTYLE, "http://www.scalastyle.org/", "");
 
   private final String url;
   private final String name;


### PR DESCRIPTION
**Summary**

Adds information about ScalaStyle, which is already compatible.

ScalaStyle is a static code analysis tool for Scala which produces Checkstyle compatible output files.

Reference: 
http://www.scalastyle.org/

>  If you have come across Checkstyle for Java, then you’ll have a good idea what scalastyle is

http://www.scalastyle.org/sbt.html

>  This produces a list of errors on the console, as well as an XML result file target/scalastyle-result.xml (CheckStyle compatible format).

Example of a report is shown here: https://github.com/scalastyle/scalastyle/blob/5c4bb3e1d6b7666c4546bbbd10c4d503455bbc9e/src/test/scala/org/scalastyle/OutputTest.scala

```<?xml version="1.0" encoding="UTF-8"?>
<checkstyle version="5.0">
 <file name="foo">
  <error column="2" line="1" source="org.scalastyle.file.FileLengthChecker" severity="error" message="custom"></error>
  <error column="4" line="3" source="org.scalastyle.file.FileLengthChecker" severity="error" message="custom 3"></error>
 </file>
 <file name="bar">
  <error source="org.scalastyle.file.FileLengthChecker" severity="warning" message="barbar.message"></error>
  <error source="org.scalastyle.file.FileLengthChecker" severity="info" message="bazbar.message"></error>
  <error column="6" line="5" source="org.scalastyle.file.FileLengthChecker" severity="error" message="bazbaz"></error>
  <error column="8" line="7" severity="error" message="noClass"></error>
 </file>
</checkstyle>```

Note: i didn't know if the documentation is manually updated so I did it. Not sure if I also should update documentation on the other related plugins (comments, gitlab, maven, jenkins, and so on)