### PR TITLE
 Add support for golangci-lint flavoured Checkstyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A number of **parsers** have been implemented. Some **parsers** can parse output
 | [_FxCop_](https://en.wikipedia.org/wiki/FxCop)                                        | `FXCOP`              | 
 | [_GCC_](https://gcc.gnu.org/)                                                         | `CLANG`              | 
 | [_Gendarme_](http://www.mono-project.com/docs/tools+libraries/tools/gendarme/)        | `GENDARME`           | 
+| [_GolangCI-Lint_](https://github.com/golangci/golangci-lint/)                         | `CHECKSTYLE`         | With `--out-format=checkstyle`.
 | [_GoLint_](https://github.com/golang/lint)                                            | `GOLINT`             | 
 | [_GoVet_](https://golang.org/cmd/vet/)                                                | `GOLINT`             | Same format as GoLint.
 | [_GoogleErrorProne_](https://github.com/google/error-prone)                           | `GOOGLEERRORPRONE`   | 

--- a/src/main/java/se/bjurr/violations/lib/parsers/CheckStyleParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/CheckStyleParser.java
@@ -26,6 +26,8 @@ public class CheckStyleParser implements ViolationsParser {
     for (final String fileChunk : files) {
       final String filename = getAttribute(fileChunk, "name");
       final List<String> errors = getChunks(fileChunk, "<error", "/>");
+      final List<String> longFormErrors = getChunks(fileChunk, "<error", "</error>");
+      errors.addAll(longFormErrors);
       for (final String errorChunk : errors) {
         final Integer line = getIntegerAttribute(errorChunk, "line");
         final Optional<Integer> column = findIntegerAttribute(errorChunk, "column");

--- a/src/test/java/se/bjurr/violations/lib/CheckstyleTest.java
+++ b/src/test/java/se/bjurr/violations/lib/CheckstyleTest.java
@@ -184,4 +184,41 @@ public class CheckstyleTest {
     assertThat(actual.get(0).getReporter()) //
         .isEqualTo("PHP");
   }
+
+  @Test
+  public void testThatGolangCILintViolationsCanBeParsed() {
+    final List<Violation> actual = violationsApi() //
+        .withPattern(".*/checkstyle/golangci-lint\\.xml$") //
+        .inFolder(rootFolder) //
+        .findAll(CHECKSTYLE) //
+        .violations();
+
+    assertThat(actual) //
+        .containsExactly( //
+            violationBuilder() //
+                .setParser(CHECKSTYLE) //
+                .setReporter(CHECKSTYLE.name()) //
+                .setFile("pkg/clients/azure/redis/redis.go") //
+                .setSource("") //
+                .setStartLine(28) //
+                .setEndLine(28) //
+                .setColumn(0) //
+                .setMessage("File is not `goimports`-ed") //
+                .setRule("goimports") //
+                .setSeverity(ERROR) //
+                .build(), //
+            violationBuilder() //
+                .setParser(CHECKSTYLE) //
+                .setReporter(CHECKSTYLE.name()) //
+                .setFile("pkg/clients/azure/redis/redis.go") //
+                .setSource("") //
+                .setStartLine(41) //
+                .setEndLine(41) //
+                .setColumn(1) //
+                .setMessage("exported function `NewClient` should have comment or be unexported") //
+                .setRule("golint") //
+                .setSeverity(ERROR) //
+                .build() //
+        );
+    }
 }

--- a/src/test/resources/checkstyle/golangci-lint.xml
+++ b/src/test/resources/checkstyle/golangci-lint.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="5.0"><file name="pkg/clients/azure/redis/redis.go"><error column="0" line="28" message="File is not `goimports`-ed" severity="error" source="goimports"></error><error column="1" line="41" message="exported function `NewClient` should have comment or be unexported" severity="error" source="golint"></error></file></checkstyle>


### PR DESCRIPTION
aka Checkstyle 5.0, apparently.

I've added an actual [golangci-lint](https://github.com/golangci/golangci-lint) generated Checkstyle XML file as a test fixture. I noticed your Jenkins Github plugin was not finding any issues with the file, seemingly because it (incorrectly?) uses `<error></error>` rather than `<error />`.