### PR TITLE
Add Violation.endColumn property

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/model/Violation.java
+++ b/src/main/java/se/bjurr/violations/lib/model/Violation.java
@@ -16,6 +16,7 @@ public class Violation implements Serializable, Comparable<Violation> {
 
     private Integer column;
     private Integer endLine;
+    private Integer endColumn;
     private String file;
     private String message;
     private Parser parser;
@@ -41,6 +42,11 @@ public class Violation implements Serializable, Comparable<Violation> {
 
     public ViolationBuilder setEndLine(final Integer endLine) {
       this.endLine = endLine;
+      return this;
+    }
+
+    public ViolationBuilder setEndColumn(final Integer endColumn) {
+      this.endColumn = endColumn;
       return this;
     }
 
@@ -118,6 +124,7 @@ public class Violation implements Serializable, Comparable<Violation> {
 
   private Integer column;
   private final Integer endLine;
+  private final Integer endColumn;
   private final String file;
   private final String message;
   /** The algorithm, the format, used. */
@@ -144,6 +151,7 @@ public class Violation implements Serializable, Comparable<Violation> {
   public Violation() {
     startLine = null;
     endLine = null;
+    endColumn = null;
     severity = null;
     message = null;
     file = null;
@@ -166,6 +174,7 @@ public class Violation implements Serializable, Comparable<Violation> {
     startLine = checkNotNull(vb.startLine, "startline");
     endLine = firstNonNull(vb.endLine, vb.startLine);
     column = vb.column;
+    endColumn = vb.endColumn;
     severity = checkNotNull(vb.severity, "severity");
     message = checkNotNull(emptyToNull(vb.message), "message");
     file = checkNotNull(emptyToNull(vb.file), "file").replaceAll("\\\\", "/");
@@ -181,6 +190,7 @@ public class Violation implements Serializable, Comparable<Violation> {
     reporter = v.reporter;
     startLine = v.startLine;
     endLine = v.endLine;
+    endColumn = v.endColumn;
     column = v.column;
     severity = v.severity;
     message = v.message;
@@ -223,6 +233,13 @@ public class Violation implements Serializable, Comparable<Violation> {
         return false;
       }
     } else if (!endLine.equals(other.endLine)) {
+      return false;
+    }
+    if (endColumn == null) {
+      if (other.endColumn != null) {
+        return false;
+      }
+    } else if (!endColumn.equals(other.endColumn)) {
       return false;
     }
     if (file == null) {
@@ -298,6 +315,10 @@ public class Violation implements Serializable, Comparable<Violation> {
     return endLine;
   }
 
+  public Integer getEndColumn() {
+    return endColumn;
+  }
+
   public String getFile() {
     return file;
   }
@@ -358,6 +379,7 @@ public class Violation implements Serializable, Comparable<Violation> {
     result = prime * result + (category == null ? 0 : category.hashCode());
     result = prime * result + (column == null ? 0 : column.hashCode());
     result = prime * result + (endLine == null ? 0 : endLine.hashCode());
+    result = prime * result + (endColumn == null ? 0 : endColumn.hashCode());
     result = prime * result + (file == null ? 0 : file.hashCode());
     result = prime * result + (group == null ? 0 : group.hashCode());
     result = prime * result + (message == null ? 0 : message.hashCode());
@@ -377,6 +399,8 @@ public class Violation implements Serializable, Comparable<Violation> {
         + column
         + ", endLine="
         + endLine
+        + ", endColumn="
+        + endColumn
         + ", file="
         + file
         + ", message="

--- a/src/main/java/se/bjurr/violations/lib/parsers/PMDParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/PMDParser.java
@@ -31,6 +31,7 @@ public class PMDParser implements ViolationsParser {
         final Integer beginLine = getIntegerAttribute(violationChunk, "beginline");
         final Integer endLine = getIntegerAttribute(violationChunk, "endline");
         final Optional<Integer> beginColumn = findIntegerAttribute(violationChunk, "begincolumn");
+        final Optional<Integer> endColumn = findIntegerAttribute(violationChunk, "endcolumn");
         final String rule = getAttribute(violationChunk, "rule").trim();
         final Optional<String> ruleSetOpt = findAttribute(violationChunk, "ruleset");
         final Optional<String> externalInfoUrlOpt =
@@ -46,6 +47,7 @@ public class PMDParser implements ViolationsParser {
                 .setStartLine(beginLine) //
                 .setEndLine(endLine) //
                 .setColumn(beginColumn.orElse(null)) //
+                .setEndColumn(endColumn.orElse(null)) //
                 .setFile(filename) //
                 .setSeverity(severity) //
                 .setRule(rule) //

--- a/src/main/java/se/bjurr/violations/lib/parsers/SonarParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/SonarParser.java
@@ -20,7 +20,9 @@ public class SonarParser implements ViolationsParser {
     int line;
     SonarIssueTextRange textRange;
     Integer startLine;
+    Integer startOffset;
     Integer endLine;
+    Integer endOffset;
     String message;
     String severity;
     String rule;
@@ -77,7 +79,9 @@ public class SonarParser implements ViolationsParser {
 
   static class SonarIssueTextRange {
     int startLine;
+    int startOffset;
     int endLine;
+    int endOffset;
   }
 
   static class SonarReport {
@@ -110,7 +114,18 @@ public class SonarParser implements ViolationsParser {
         // textRange field for the
         // startLine/endLine fields.
         issue.startLine = issue.textRange.startLine;
+        issue.startOffset = issue.textRange.startOffset;
         issue.endLine = issue.textRange.endLine;
+        issue.endOffset = issue.textRange.endOffset;
+      }
+
+      Integer startColumn = null;
+      if (issue.startOffset != null) {
+        startColumn = issue.startOffset + 1;
+      }
+      Integer endColumn = null;
+      if (issue.endOffset != null) {
+        endColumn = issue.endOffset + 1;
       }
 
       if (issue.startLine == null || issue.getSeverity() == null) {
@@ -127,12 +142,14 @@ public class SonarParser implements ViolationsParser {
               .setFile(issue.getFile()) //
               .setCategory(issue.getCategory()) //
               .setEndLine(issue.endLine) //
+              .setEndColumn(endColumn) //
               .setMessage(issue.message) //
               .setParser(SONAR) //
               .setReporter(SONAR.name()) //
               .setRule(issue.rule) //
               .setSeverity(issue.getSeverity()) //
               .setStartLine(issue.startLine) //
+              .setColumn(startColumn) //
               .setSource(issue.component) //
               .build());
     }

--- a/src/test/java/se/bjurr/violations/lib/PMDTest.java
+++ b/src/test/java/se/bjurr/violations/lib/PMDTest.java
@@ -35,8 +35,12 @@ public class PMDTest {
         .doesNotContain("CDATA");
     assertThat(violationZero.getStartLine()) //
         .isEqualTo(16);
+    assertThat(violationZero.getColumn()) //
+        .isEqualTo(17);
     assertThat(violationZero.getEndLine()) //
         .isEqualTo(16);
+    assertThat(violationZero.getEndColumn()) //
+        .isEqualTo(34);
     assertThat(violationZero.getRule()) //
         .isEqualTo("OverrideBothEqualsAndHashcode");
     assertThat(violationZero.getSeverity()) //
@@ -65,8 +69,12 @@ public class PMDTest {
         .doesNotContain("CDATA");
     assertThat(violationZero.getStartLine()) //
         .isEqualTo(39);
+    assertThat(violationZero.getColumn()) //
+        .isEqualTo(17);
     assertThat(violationZero.getEndLine()) //
         .isEqualTo(39);
+    assertThat(violationZero.getEndColumn()) //
+        .isEqualTo(18);
     assertThat(violationZero.getRule()) //
         .isEqualTo("RULE5");
     assertThat(violationZero.getSeverity()) //
@@ -96,8 +104,12 @@ public class PMDTest {
         .doesNotContain("CDATA");
     assertThat(violationZero.getStartLine()) //
         .isEqualTo(1);
+    assertThat(violationZero.getColumn()) //
+        .isEqualTo(1);
     assertThat(violationZero.getEndLine()) //
         .isEqualTo(149);
+    assertThat(violationZero.getEndColumn()) //
+        .isEqualTo(3);
     assertThat(violationZero.getRule()) //
         .isEqualTo("ApplicationAccessLimit");
     assertThat(violationZero.getSeverity()) //

--- a/src/test/java/se/bjurr/violations/lib/SonarTest.java
+++ b/src/test/java/se/bjurr/violations/lib/SonarTest.java
@@ -3,6 +3,7 @@ package se.bjurr.violations.lib;
 import static org.assertj.core.api.Assertions.assertThat;
 import static se.bjurr.violations.lib.TestUtils.getRootFolder;
 import static se.bjurr.violations.lib.ViolationsApi.violationsApi;
+import static se.bjurr.violations.lib.model.SEVERITY.ERROR;
 import static se.bjurr.violations.lib.model.SEVERITY.INFO;
 import static se.bjurr.violations.lib.reports.Parser.SONAR;
 
@@ -56,6 +57,28 @@ public class SonarTest {
 
     assertThat(actual) //
         .hasSize(88);
+
+    final Violation actualViolationZero = actual.get(0);
+    assertThat(actualViolationZero.getFile()) //
+        .isEqualTo("app/controllers/API.java");
+    assertThat(actualViolationZero.getStartLine()) //
+        .isEqualTo(340);
+    assertThat(actualViolationZero.getColumn()) //
+        .isEqualTo(26);
+    assertThat(actualViolationZero.getEndLine()) //
+        .isEqualTo(340);
+    assertThat(actualViolationZero.getEndColumn()) //
+        .isEqualTo(51);
+    assertThat(actualViolationZero.getMessage()) //
+        .startsWith("Use try-with-resources or close this");
+    assertThat(actualViolationZero.getReporter()) //
+        .isEqualTo(SONAR.name());
+    assertThat(actualViolationZero.getRule()) //
+        .isEqualTo("squid:S2095");
+    assertThat(actualViolationZero.getSeverity()) //
+        .isEqualTo(ERROR);
+    assertThat(actualViolationZero.getSource()) //
+        .isEqualTo("pki-middleware-sonar:app/controllers/API.java");
   }
 
   @Test


### PR DESCRIPTION
Some static analysis tools (PMD, Sonar) save full source position for their issues with start line, start column, end line and end column.

Currently `Violation` class doesn't have `endColumn` property.

This PR:
* Adds `Violation.endColumn` property
* Makes PMD and Sonar parsers handle this property