### PR TITLE
Fix MyPy parser swallowing parts of error message

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/parsers/MyPyParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/MyPyParser.java
@@ -20,7 +20,7 @@ public class MyPyParser implements ViolationsParser {
   public Set<Violation> parseReportOutput(
       final String reportContent, final ViolationsLogger violationsLogger) throws Exception {
     final Set<Violation> violations = new TreeSet<>();
-    final List<List<String>> partsPerLine = getLines(reportContent, "^(.*):(\\d+): (.*): (.*)$");
+    final List<List<String>> partsPerLine = getLines(reportContent, "^(.*):(\\d+): ([^:]*): (.*)$");
     for (final List<String> parts : partsPerLine) {
       final String fileName = parts.get(1);
       Integer lineNumber = 0;

--- a/src/test/java/se/bjurr/violations/lib/MyPyTest.java
+++ b/src/test/java/se/bjurr/violations/lib/MyPyTest.java
@@ -28,7 +28,7 @@ public class MyPyTest {
             .violations();
 
     assertThat(actual) //
-        .hasSize(5);
+        .hasSize(6);
 
     assertThat(new ArrayList<>(actual).get(3)) //
         .isEqualTo( //
@@ -48,6 +48,17 @@ public class MyPyTest {
                 .setFile("fs/cs/backend/log.py") //
                 .setStartLine(17) //
                 .setMessage("\"LogRecord\" has no attribute \"tenant_id\"") //
+                .setSeverity(ERROR) //
+                .build() //
+            );
+
+    assertThat(new ArrayList<>(actual).get(5)) //
+        .isEqualTo( //
+            violationBuilder() //
+                .setParser(MYPY) //
+                .setFile("tests/test_xyz.py") //
+                .setStartLine(123) //
+                .setMessage("Need type annotation for 'a' (hint: \"a: List[<type>] = ...\")") //
                 .setSeverity(ERROR) //
                 .build() //
             );

--- a/src/test/resources/mypy/mypy.txt
+++ b/src/test/resources/mypy/mypy.txt
@@ -6,3 +6,4 @@ fs/cs/backend/errorhandler.py:16: error: The return type of "__init__" must be N
 fs/cs/backend/api.py: note: At top level:
 fs/cs/backend/api.py:23: error: ContextManager[Any] not callable
 tests/test_schema.py:864: error: Name 'test_nested_only_and_exclude' already defined
+tests/test_xyz.py:123: error: Need type annotation for 'a' (hint: "a: List[<type>] = ...")


### PR DESCRIPTION
It turns out that MyPy may print error messages that contain colons `:` which are used by the parser to delimit fields. This causes the parser to swallow the part of the error message between `error:` and the last colon `:` in the error message.

Fortunately we can just non-greedy match the error specifier as that most likely will always be an alphanumeric string and never contain a colon.

I've also written a test that displays the observed error behaviour. As I observed the actual bug in a work environment, I took an anonymous, equivalent error message from the MyPy test suite.