### PR TITLE
fix parse gradle kotlin column line

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/parsers/KotlinGradleParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/KotlinGradleParser.java
@@ -21,7 +21,7 @@ public class KotlinGradleParser implements ViolationsParser {
       throws Exception {
     final Set<Violation> violations = new TreeSet<>();
     final List<List<String>> partsPerLine =
-        getLines(string, "(w|e):([^:]*)[^\\d]+?(\\d+?)[^\\d]+?(\\d+?)[^:]+?:(.*)");
+        getLines(string, "(w|e):([^:]*)[^\\d]+?(\\d+?)[^\\d]+?(\\d+)[^:]+?:(.*)");
     for (final List<String> parts : partsPerLine) {
       final String severity = parts.get(1).trim();
       final String filename = parts.get(2).trim();

--- a/src/main/java/se/bjurr/violations/lib/parsers/KotlinGradleParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/KotlinGradleParser.java
@@ -21,7 +21,7 @@ public class KotlinGradleParser implements ViolationsParser {
       throws Exception {
     final Set<Violation> violations = new TreeSet<>();
     final List<List<String>> partsPerLine =
-        getLines(string, "(w|e):([^:]*)[^\\d]+?(\\d+?)[^\\d]+?(\\d+)[^:]+?:(.*)");
+        getLines(string, "(w|e):(.+?):[\\s(]+?(\\d+)[^\\d]+?(\\d+)[^:]+?:(.*)");
     for (final List<String> parts : partsPerLine) {
       final String severity = parts.get(1).trim();
       final String filename = parts.get(2).trim();

--- a/src/test/java/se/bjurr/violations/lib/KotlinGradleTest.java
+++ b/src/test/java/se/bjurr/violations/lib/KotlinGradleTest.java
@@ -39,5 +39,7 @@ public class KotlinGradleTest {
         .isEqualTo("");
     assertThat(violation0.getParser()) //
         .isEqualTo(KOTLINGRADLE);
+    assertThat(violation0.getColumn())
+            .isEqualTo(87);
   }
 }

--- a/src/test/java/se/bjurr/violations/lib/KotlinGradleTest.java
+++ b/src/test/java/se/bjurr/violations/lib/KotlinGradleTest.java
@@ -25,7 +25,7 @@ public class KotlinGradleTest {
             .violations();
 
     assertThat(actual) //
-        .hasSize(3);
+        .hasSize(4);
 
     final Violation violation0 = new ArrayList<>(actual).get(0);
     assertThat(violation0.getMessage()) //
@@ -41,5 +41,11 @@ public class KotlinGradleTest {
         .isEqualTo(KOTLINGRADLE);
     assertThat(violation0.getColumn())
             .isEqualTo(87);
+    
+    final Violation violation3 = new ArrayList<>(actual).get(3);
+    assertThat(violation3.getFile()).
+            isEqualTo("C:/Users/User/Documents/testProject/src/main/java/ru/novikov/maps/CameraPosition.kt");
+    assertThat(violation3.getStartLine())
+            .isEqualTo(25);
   }
 }

--- a/src/test/resources/kotlingradle/kotlin-gradle-example.txt
+++ b/src/test/resources/kotlingradle/kotlin-gradle-example.txt
@@ -25,3 +25,4 @@ Found android support method: Landroid/support/v7/widget/ToolbarWidgetWrapper$1;
 w: /Users/scottkennedy/project/src/main/java/com/example/Test.kt: (13, 87): Elvis operator (?:) always returns the left operand of non-nullable type String
 w: /Users/wolfs/projects/gradle/build-tool-release/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt: (75, 54): Unchecked cast: Any? to List<CapabilitySpec>
 w: /home/bjerre/workspace/yet-another-kotlin-vs-java-comparison/src/main/kotlin/basics/controliiiflow/p01assigniiifromiiiif/Example.kt: (17, 9): Variable 'hejsan' is never used
+w: C:\Users\User\Documents\testProject\src\main\java\ru\novikov\maps\CameraPosition.kt: (25, 17): Variable some is never used


### PR DESCRIPTION
I found some issues with KotlinGradle. 
1.  Wrong parsing column line 
![image](https://user-images.githubusercontent.com/8822182/100385487-c9adad80-3033-11eb-9d4a-51d283e437f3.png)
2. Wrong parsing Windows-style path e.g. `w: C:\Users\User\Document`