### PR TITLE
Generated code fails to parse because it does not have line information

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/parsers/JacocoParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/JacocoParser.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static se.bjurr.violations.lib.model.Violation.violationBuilder;
 import static se.bjurr.violations.lib.reports.Parser.JACOCO;
+import static se.bjurr.violations.lib.util.ViolationParserUtils.findIntegerAttribute;
 import static se.bjurr.violations.lib.util.ViolationParserUtils.getAttribute;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -56,7 +57,7 @@ public class JacocoParser implements ViolationsParser {
                 builder.setMethodDetails(
                     getAttribute(xmlr, "name"),
                     getAttribute(xmlr, "desc"),
-                    Integer.parseInt(getAttribute(xmlr, "line")));
+                    findIntegerAttribute(xmlr, "line").orElse(0));
                 break;
               case "counter":
                 builder.setCounterDetails(
@@ -114,6 +115,9 @@ public class JacocoParser implements ViolationsParser {
     }
 
     public Optional<Violation> build(final int minLineCount, final double minCoverage) {
+      if (methodLine == 0) {
+        return Optional.empty();
+      }
       final CoverageDetails cl = this.coverage.get("LINE");
       if (cl.getTotal() < minLineCount) {
         return Optional.empty();

--- a/src/test/java/se/bjurr/violations/lib/JacocoParserTest.java
+++ b/src/test/java/se/bjurr/violations/lib/JacocoParserTest.java
@@ -179,4 +179,19 @@ public class JacocoParserTest {
     assertThat(violation1.getStartLine()) //
         .isEqualTo(71);
   }
+
+  @Test
+  public void shouldSkipViolationWithoutLineInfo() {
+    final String rootFolder = getRootFolder();
+
+    final Set<Violation> actual =
+            violationsApi() //
+                    .withPattern(".*/jacoco/shouldSkipViolationWithoutLineInfo\\.xml$") //
+                    .inFolder(rootFolder) //
+                    .findAll(JACOCO) //
+                    .violations();
+
+    assertThat(actual) //
+            .hasSize(0);
+  }
 }

--- a/src/test/resources/jacoco/shouldSkipViolationWithoutLineInfo.xml
+++ b/src/test/resources/jacoco/shouldSkipViolationWithoutLineInfo.xml
@@ -1,0 +1,11 @@
+<report name="violations-lib">
+  <package name="se/bjurr/violations/lib/reports">
+    <class name="se/bjurr/violations/lib/reports/Parser" sourcefilename="Parser.java">
+      <method name="findViolations"
+        desc="(Lse/bjurr/violations/lib/ViolationsLogger;Ljava/util/List;)Ljava/util/Set;">
+        <counter type="INSTRUCTION" missed="52" covered="40"/>
+        <counter type="LINE" missed="1" covered="3"/>
+      </method>
+    </class>
+  </package>
+</report>


### PR DESCRIPTION
In the case of generated code, the jacoco xml does not contain line information. In those cases, the JACOCO parser fails, and this is a fix for that particular situation. 