### PR TITLE
add valgrind xml output parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ A number of **parsers** have been implemented. Some **parsers** can parse output
 | [_StyleCop_](https://stylecop.codeplex.com/)                                          | `STYLECOP`           | 
 | [_SwiftLint_](https://github.com/realm/SwiftLint)                                     | `CHECKSTYLE`         | With `--reporter checkstyle`.
 | [_TSLint_](https://palantir.github.io/tslint/usage/cli/)                              | `CHECKSTYLE`         | With `-t checkstyle`
+| [_Valgrind_](https://valgrind.org/)                                                   | `VALGRIND`           | With `--xml=yes`.
 | [_XMLLint_](http://xmlsoft.org/xmllint.html)                                          | `XMLLINT`            | 
 | [_XUnit_](https://xunit.net/)                                                         | `XUNIT`              | It only contains the failures.
 | [_YAMLLint_](https://yamllint.readthedocs.io/en/stable/index.html)                    | `YAMLLINT`           | With `-f parsable`

--- a/src/main/java/se/bjurr/violations/lib/parsers/ValgrindParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/ValgrindParser.java
@@ -1,0 +1,343 @@
+package se.bjurr.violations.lib.parsers;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static se.bjurr.violations.lib.model.SEVERITY.ERROR;
+import static se.bjurr.violations.lib.model.Violation.violationBuilder;
+import static se.bjurr.violations.lib.reports.Parser.VALGRIND;
+import static se.bjurr.violations.lib.util.ViolationParserUtils.createXmlReader;
+
+import com.google.gson.Gson;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
+
+import se.bjurr.violations.lib.ViolationsLogger;
+import se.bjurr.violations.lib.model.Violation;
+
+public class ValgrindParser implements ViolationsParser {
+
+  @Override
+  public Set<Violation> parseReportOutput(
+      final String reportContent, final ViolationsLogger violationsLogger) throws Exception {
+    final Set<Violation> violations = new TreeSet<>();
+    try (InputStream input = new ByteArrayInputStream(reportContent.getBytes(UTF_8))) {
+      final XMLStreamReader xml = createXmlReader(input);
+      final Gson gson = new Gson();
+
+      String reporter = null;
+      String source = null;
+      String group = null;
+      String tid = null;
+      String threadName = null;
+      String rule = null;
+      String what = null;
+      List<String> auxWhats = null;
+      Element element = null;
+      List<List<StackFrame>> stacks = null;
+      List<StackFrame> stack = null;
+      StackFrame frame = null;
+      String suppression = null;
+
+      while (xml.hasNext()) {
+        final int eventType = xml.next();
+        if (eventType == XMLStreamConstants.START_ELEMENT) {
+          if ((element == null) && xml.getLocalName().equalsIgnoreCase("tool")) {
+            element = Element.TOOL;
+          } else if ((element == null) && xml.getLocalName().equalsIgnoreCase("args")) {
+            element = Element.ARGS;
+          } else if ((element == Element.ARGS) && xml.getLocalName().equalsIgnoreCase("argv")) {
+            element = Element.ARGV;
+          } else if ((element == Element.ARGV) && xml.getLocalName().equalsIgnoreCase("exe")) {
+            element = Element.EXE;
+          } else if (xml.getLocalName().equalsIgnoreCase("error")) {
+            element = Element.ERROR;
+            tid = null;
+            threadName = null;
+            group = null;
+            rule = null;
+            what = null;
+            auxWhats = new ArrayList<>();
+            frame = null;
+            stack = null;
+            stacks = new ArrayList<>();
+            suppression = null;
+          } else if (element == Element.ERROR) {
+            if (xml.getLocalName().equalsIgnoreCase("unique")) {
+              element = Element.UNIQUE;
+            } else if (xml.getLocalName().equalsIgnoreCase("tid")) {
+              element = Element.TID;
+            } else if (xml.getLocalName().equalsIgnoreCase("threadname")) {
+              element = Element.THREADNAME;
+            } else if (xml.getLocalName().equalsIgnoreCase("kind")) {
+              element = Element.KIND;
+            } else if (xml.getLocalName().equalsIgnoreCase("what")) {
+              element = Element.WHAT;
+            } else if (xml.getLocalName().equalsIgnoreCase("auxwhat")) {
+              element = Element.AUXWHAT;
+            } else if (xml.getLocalName().equalsIgnoreCase("xwhat")) {
+              element = Element.XWHAT;
+            } else if (xml.getLocalName().equalsIgnoreCase("xauxwhat")) {
+              element = Element.XAUXWHAT;
+            } else if (xml.getLocalName().equalsIgnoreCase("stack")) {
+              element = Element.STACK;
+              stack = new ArrayList<>();
+            } else if (xml.getLocalName().equalsIgnoreCase("suppression")) {
+              element = Element.SUPPRESSION;
+            }
+          } else if ((element == Element.STACK) && xml.getLocalName().equalsIgnoreCase("frame")) {
+            frame = new StackFrame();
+            element = Element.FRAME;
+          } else if (element == Element.FRAME) {
+            if (xml.getLocalName().equalsIgnoreCase("ip")) {
+              element = Element.IP;
+            } else if (xml.getLocalName().equalsIgnoreCase("obj")) {
+              element = Element.OBJ;
+            } else if (xml.getLocalName().equalsIgnoreCase("fn")) {
+              element = Element.FN;
+            } else if (xml.getLocalName().equalsIgnoreCase("dir")) {
+              element = Element.DIR;
+            } else if (xml.getLocalName().equalsIgnoreCase("file")) {
+              element = Element.FILE;
+            } else if (xml.getLocalName().equalsIgnoreCase("line")) {
+              element = Element.LINE;
+            }
+          } else if (xml.getLocalName().equalsIgnoreCase("text")) {
+            if (element == Element.XWHAT) {
+              element = Element.XWHAT_TEXT;
+            } else if (element == Element.XAUXWHAT) {
+              element = Element.XAUXWHAT_TEXT;
+            }
+          } else if ((element == Element.SUPPRESSION) && xml.getLocalName().equalsIgnoreCase("rawtext")) {
+            element = Element.SUPPRESSION_RAWTEXT;
+          }
+        } else if (eventType == XMLStreamConstants.END_ELEMENT) {
+          if (xml.getLocalName().equalsIgnoreCase("error")) {
+            String file = Violation.NO_FILE;
+            int startLine = 0;
+
+            Map<String, String> specifics = new HashMap<>();
+
+            if (tid != null) {
+              specifics.put("tid", tid);
+            }
+
+            if (threadName != null) {
+              specifics.put("threadname", threadName);
+            }
+
+            if ((auxWhats != null) && !auxWhats.isEmpty()) {
+              specifics.put("auxwhats", gson.toJson(auxWhats));
+            }
+
+            if ((stacks != null) && !stacks.isEmpty()) {
+              for (StackFrame f: stacks.get(0)) {
+                if ((f.file != null) && !f.file.equals("vg_replace_malloc.c")) {
+                  file = f.file;
+                  startLine = f.line;
+                  break;
+                }
+              }
+
+              specifics.put("stacks", gson.toJson(stacks));
+            }
+
+            if (suppression != null) {
+              specifics.put("suppression", suppression);
+            }
+
+            violations.add(
+              violationBuilder() //
+                .setParser(VALGRIND) //
+                .setSeverity(ERROR) //
+                .setSource(source) //
+                .setRule(rule) //
+                .setFile(file) //
+                .setStartLine(startLine) //
+                .setMessage(what) //
+                .setReporter(reporter) //
+                .setGroup(group) //
+                .setSpecifics(specifics) //
+                .build());
+            element = null;
+          } else if ((element == Element.UNIQUE) && xml.getLocalName().equalsIgnoreCase("unique")) {
+            element = Element.ERROR;
+          } else if ((element == Element.TID) && xml.getLocalName().equalsIgnoreCase("tid")) {
+            element = Element.ERROR;
+          } else if ((element == Element.THREADNAME) && xml.getLocalName().equalsIgnoreCase("threadname")) {
+            element = Element.ERROR;
+          } else if ((element == Element.KIND) && xml.getLocalName().equalsIgnoreCase("kind")) {
+            element = Element.ERROR;
+          } else if ((element == Element.WHAT) && xml.getLocalName().equalsIgnoreCase("what")) {
+            element = Element.ERROR;
+          } else if ((element == Element.AUXWHAT) && xml.getLocalName().equalsIgnoreCase("auxwhat")) {
+            element = Element.ERROR;
+          } else if ((element == Element.XWHAT) && xml.getLocalName().equalsIgnoreCase("xwhat")) {
+            element = Element.ERROR;
+          } else if ((element == Element.XWHAT_TEXT) && xml.getLocalName().equalsIgnoreCase("text")) {
+            element = Element.XWHAT;
+          } else if ((element == Element.XAUXWHAT) && xml.getLocalName().equalsIgnoreCase("xwhat")) {
+            element = Element.ERROR;
+          } else if ((element == Element.XAUXWHAT_TEXT) && xml.getLocalName().equalsIgnoreCase("text")) {
+            element = Element.XAUXWHAT;
+          } else if ((element == Element.STACK) && xml.getLocalName().equalsIgnoreCase("stack")) {
+            if ((stacks != null) && (stack != null)) {
+              stacks.add(stack);
+              stack = null;
+            }
+            element = Element.ERROR;
+          } else if ((element == Element.FRAME) && xml.getLocalName().equalsIgnoreCase("frame")) {
+            if ((stack != null) && (frame != null)) {
+              stack.add(frame);
+              frame = null;
+            }
+            element = Element.STACK;
+          } else if ((element == Element.IP) && xml.getLocalName().equalsIgnoreCase("ip")) {
+            element = Element.FRAME;
+          } else if ((element == Element.OBJ) && xml.getLocalName().equalsIgnoreCase("obj")) {
+            element = Element.FRAME;
+          } else if ((element == Element.FN) && xml.getLocalName().equalsIgnoreCase("fn")) {
+            element = Element.FRAME;
+          } else if ((element == Element.DIR) && xml.getLocalName().equalsIgnoreCase("dir")) {
+            element = Element.FRAME;
+          } else if ((element == Element.FILE) && xml.getLocalName().equalsIgnoreCase("file")) {
+            element = Element.FRAME;
+          } else if ((element == Element.LINE) && xml.getLocalName().equalsIgnoreCase("line")) {
+            element = Element.FRAME;
+          } else if ((element == Element.TOOL) && xml.getLocalName().equalsIgnoreCase("tool")) {
+            element = null;
+          } else if ((element == Element.ARGS) && xml.getLocalName().equalsIgnoreCase("args")) {
+            element = null;
+          } else if ((element == Element.ARGV) && xml.getLocalName().equalsIgnoreCase("argv")) {
+            element = Element.ARGS;
+          } else if ((element == Element.EXE) && xml.getLocalName().equalsIgnoreCase("exe")) {
+            element = Element.ARGV;
+          } else if ((element == Element.SUPPRESSION) && xml.getLocalName().equalsIgnoreCase("suppression")) {
+            element = Element.ERROR;
+          } else if ((element == Element.SUPPRESSION_RAWTEXT) && xml.getLocalName().equalsIgnoreCase("rawtext")) {
+            element = Element.SUPPRESSION;
+          }
+        } else if ((element != null) && (eventType == XMLStreamConstants.CHARACTERS)) {
+          switch (element)
+          {
+            case TOOL:
+              reporter = xml.getText();
+              break;
+            case EXE:
+              source = xml.getText();
+              break;
+            case UNIQUE:
+              group = xml.getText();
+              break;
+            case TID:
+              tid = xml.getText();
+              break;
+            case THREADNAME:
+              threadName = xml.getText();
+              break;
+            case KIND:
+              rule = xml.getText();
+              break;
+            case WHAT:
+              what = xml.getText();
+              break;
+            case XWHAT_TEXT:
+              what = xml.getText();
+              break;
+            case AUXWHAT:
+              if (auxWhats != null) {
+                auxWhats.add(xml.getText());
+              }
+              break;
+            case XAUXWHAT_TEXT:
+              if (auxWhats != null) {
+                auxWhats.add(xml.getText());
+              }
+              break;
+            case IP:
+              if (frame != null) {
+                frame.ip = xml.getText();
+              }
+              break;
+            case OBJ:
+              if (frame != null) {
+                frame.obj = xml.getText();
+              }
+              break;
+            case FN:
+              if (frame != null) {
+                frame.fn = xml.getText();
+              }
+              break;
+            case DIR:
+              if (frame != null) {
+                frame.dir = xml.getText();
+              }
+              break;
+            case FILE:
+              if (frame != null) {
+                frame.file = xml.getText();
+              }
+              break;
+            case LINE:
+              if (frame != null) {
+                frame.line = Integer.parseInt(xml.getText());
+              }
+              break;
+            case SUPPRESSION_RAWTEXT:
+              if (!xml.getText().isBlank()) {
+                suppression = xml.getText().strip();
+              }
+              break;
+          }
+        }
+      }
+    }
+
+    return violations;
+  }
+
+  private enum Element {
+    TOOL,
+    ARGS,
+    ARGV,
+    EXE,
+    ERROR,
+    UNIQUE,
+    TID,
+    THREADNAME,
+    KIND,
+    WHAT,
+    XWHAT,
+    XWHAT_TEXT,
+    AUXWHAT,
+    XAUXWHAT,
+    XAUXWHAT_TEXT,
+    STACK,
+    FRAME,
+    IP,
+    OBJ,
+    FN,
+    DIR,
+    FILE,
+    LINE,
+    SUPPRESSION,
+    SUPPRESSION_RAWTEXT,
+  }
+
+  private final class StackFrame {
+    public String ip;
+    public String obj;
+    public String fn;
+    public String dir;
+    public String file;
+    public int line;
+  };
+}

--- a/src/main/java/se/bjurr/violations/lib/reports/Parser.java
+++ b/src/main/java/se/bjurr/violations/lib/reports/Parser.java
@@ -46,6 +46,7 @@ import se.bjurr.violations.lib.parsers.SbtScalacParser;
 import se.bjurr.violations.lib.parsers.SimianParser;
 import se.bjurr.violations.lib.parsers.SonarParser;
 import se.bjurr.violations.lib.parsers.StyleCopParser;
+import se.bjurr.violations.lib.parsers.ValgrindParser;
 import se.bjurr.violations.lib.parsers.ViolationsParser;
 import se.bjurr.violations.lib.parsers.XMLLintParser;
 import se.bjurr.violations.lib.parsers.XUnitParser;
@@ -97,7 +98,8 @@ public enum Parser {
   DOCFX(new DocFXParser()), //
   PCLINT(new PCLintParser()), //
   CODECLIMATE(new CodeClimateParser()), //
-  XUNIT(new XUnitParser());
+  XUNIT(new XUnitParser()), //
+  VALGRIND(new ValgrindParser());
 
   private transient ViolationsParser violationsParser;
 

--- a/src/main/java/se/bjurr/violations/lib/reports/Reporter.java
+++ b/src/main/java/se/bjurr/violations/lib/reports/Reporter.java
@@ -172,6 +172,7 @@ public enum Reporter {
       Parser.CHECKSTYLE,
       "https://palantir.github.io/tslint/usage/cli/",
       "With `-t checkstyle`"),
+  VALGRIND("Valgrind", Parser.VALGRIND, "https://valgrind.org/", "With `--xml=yes`."),
   XUNIT("XUnit", Parser.XUNIT, "https://xunit.net/", "It only contains the failures."),
   XMLLINT("XMLLint", Parser.XMLLINT, "http://xmlsoft.org/xmllint.html", ""),
   YAMLLINT(

--- a/src/test/java/se/bjurr/violations/lib/ValgrindTest.java
+++ b/src/test/java/se/bjurr/violations/lib/ValgrindTest.java
@@ -1,0 +1,96 @@
+package se.bjurr.violations.lib;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.bjurr.violations.lib.TestUtils.getRootFolder;
+import static se.bjurr.violations.lib.ViolationsApi.violationsApi;
+import static se.bjurr.violations.lib.model.SEVERITY.ERROR;
+import static se.bjurr.violations.lib.model.Violation.violationBuilder;
+import static se.bjurr.violations.lib.reports.Parser.VALGRIND;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+  /**
+   * valgrind --xml=yes --xml-file=valgrind_results.xml --track-origins=yes
+   * --leak-check=full --show-leak-kinds=all
+   */
+public class ValgrindTest {
+  static final String MEMCHECK_REPORTER = "memcheck";
+  static final String SOURCE = "./terrible_program";
+
+  @Test
+  public void testThatViolationsCanBeParsed() {
+    assertThat(
+        violationsApi() //
+            .withPattern(".*/valgrind/valgrind\\.xml$") //
+            .inFolder(getRootFolder()) //
+            .findAll(VALGRIND) //
+            .violations()) //
+        .containsOnly( //
+            violationBuilder() //
+                .setParser(VALGRIND) //
+                .setReporter(MEMCHECK_REPORTER) //
+                .setSource(SOURCE) //
+                .setFile("terrible_program.cpp") //
+                .setStartLine(5) //
+                .setEndLine(5) //
+                .setRule("UninitCondition") //
+                .setMessage("Conditional jump or move depends on uninitialised value(s)") //
+                .setSeverity(ERROR) //
+                .setGroup("0x0") //
+                .setSpecifics( //
+                    new HashMap<String, String>() {{ //
+                        put("tid", "1"); //
+                        put("threadname", "worst thread ever"); //
+                        put("auxwhats", "[\"Uninitialised value was created by a heap allocation\"]"); //
+                        put("stacks", "[[{\"ip\":\"0x109163\",\"obj\":\"/home/some_user/terrible_program/terrible_program\",\"fn\":\"main\",\"dir\":\"/home/some_user/terrible_program\",\"file\":\"terrible_program.cpp\",\"line\":5}]," //
+                                     + "[{\"ip\":\"0x483B20F\",\"obj\":\"/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so\",\"fn\":\"operator new[](unsigned long)\",\"dir\":\"./coregrind/m_replacemalloc\",\"file\":\"vg_replace_malloc.c\",\"line\":640}," //
+                                     +  "{\"ip\":\"0x109151\",\"obj\":\"/home/some_user/terrible_program/terrible_program\",\"fn\":\"main\",\"dir\":\"/home/some_user/terrible_program\",\"file\":\"terrible_program.cpp\",\"line\":3}]]"); //
+                        put("suppression", "{\n   <insert_a_suppression_name_here>\n   Memcheck:Cond\n   fun:main\n}"); //
+                    }})
+                .build(), //
+            violationBuilder() //
+                .setParser(VALGRIND) //
+                .setReporter(MEMCHECK_REPORTER) //
+                .setSource(SOURCE) //
+                .setFile("terrible_program.cpp") //
+                .setStartLine(10) //
+                .setEndLine(10) //
+                .setRule("InvalidWrite") //
+                .setMessage("Invalid write of size 4") //
+                .setSeverity(ERROR) //
+                .setGroup("0x1") //
+                .setSpecifics( //
+                    new HashMap<String, String>() {{ //
+                        put("tid", "1");
+                        put("auxwhats", "[\"Address 0x4dd0c90 is 0 bytes after a block of size 16 alloc\\u0027d\"]");
+                        put("stacks", "[[{\"ip\":\"0x109177\",\"obj\":\"/home/some_user/terrible_program/terrible_program\",\"fn\":\"main\",\"dir\":\"/home/some_user/terrible_program\",\"file\":\"terrible_program.cpp\",\"line\":10}]," //
+                                     + "[{\"ip\":\"0x483B20F\",\"obj\":\"/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so\",\"fn\":\"operator new[](unsigned long)\",\"dir\":\"./coregrind/m_replacemalloc\",\"file\":\"vg_replace_malloc.c\",\"line\":640}," //
+                                     +  "{\"ip\":\"0x109151\",\"obj\":\"/home/some_user/terrible_program/terrible_program\",\"fn\":\"main\",\"dir\":\"/home/some_user/terrible_program\",\"file\":\"terrible_program.cpp\",\"line\":3}]]"); //
+                        put("suppression", "{\n   <insert_a_suppression_name_here>\n   Memcheck:Addr4\n   fun:main\n}"); //
+                    }}) //
+                .build(), //
+            violationBuilder() //
+                .setParser(VALGRIND) //
+                .setReporter(MEMCHECK_REPORTER) //
+                .setSource(SOURCE) //
+                .setFile("terrible_program.cpp") //
+                .setStartLine(3) //
+                .setEndLine(3) //
+                .setRule("Leak_DefinitelyLost") //
+                .setMessage("16 bytes in 1 blocks are definitely lost in loss record 1 of 1") //
+                .setSeverity(ERROR) //
+                .setGroup("0x2") //
+                .setSpecifics( //
+                    new HashMap<String, String>() {{ //
+                        put("tid", "1"); //
+                        put("stacks", "[[{\"ip\":\"0x483B20F\",\"obj\":\"/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so\",\"fn\":\"operator new[](unsigned long)\",\"dir\":\"./coregrind/m_replacemalloc\",\"file\":\"vg_replace_malloc.c\",\"line\":640}," //
+                                      + "{\"ip\":\"0x109151\",\"obj\":\"/home/some_user/terrible_program/terrible_program\",\"fn\":\"main\",\"dir\":\"/home/some_user/terrible_program\",\"file\":\"terrible_program.cpp\",\"line\":3}]]"); //
+                        put("suppression", "{\n   <insert_a_suppression_name_here>\n   Memcheck:Leak\n   match-leak-kinds: definite\n   fun:_Znam\n   fun:main\n}");
+                    }}) //
+                .build() //
+            );
+}
+
+}

--- a/src/test/resources/valgrind/valgrind.xml
+++ b/src/test/resources/valgrind/valgrind.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0"?>
+
+<valgrindoutput>
+
+<protocolversion>4</protocolversion>
+<protocoltool>memcheck</protocoltool>
+
+<preamble>
+  <line>Memcheck, a memory error detector</line>
+  <line>Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.</line>
+  <line>Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info</line>
+  <line>Command: ./terrible_program</line>
+</preamble>
+
+<pid>36556</pid>
+<ppid>26175</ppid>
+<tool>memcheck</tool>
+
+<args>
+  <vargv>
+    <exe>/usr/bin/valgrind.bin</exe>
+    <arg>--gen-suppressions=all</arg>
+    <arg>--xml=yes</arg>
+    <arg>--xml-file=valgrind.xml</arg>
+    <arg>--track-origins=yes</arg>
+    <arg>--leak-check=full</arg>
+    <arg>--show-leak-kinds=all</arg>
+  </vargv>
+  <argv>
+    <exe>./terrible_program</exe>
+  </argv>
+</args>
+
+<status>
+  <state>RUNNING</state>
+  <time>00:00:00:00.146 </time>
+</status>
+
+<error>
+  <unique>0x0</unique>
+  <tid>1</tid>
+  <threadname>worst thread ever</threadname>
+  <kind>UninitCondition</kind>
+  <what>Conditional jump or move depends on uninitialised value(s)</what>
+  <stack>
+    <frame>
+      <ip>0x109163</ip>
+      <obj>/home/some_user/terrible_program/terrible_program</obj>
+      <fn>main</fn>
+      <dir>/home/some_user/terrible_program</dir>
+      <file>terrible_program.cpp</file>
+      <line>5</line>
+    </frame>
+  </stack>
+  <auxwhat>Uninitialised value was created by a heap allocation</auxwhat>
+  <stack>
+    <frame>
+      <ip>0x483B20F</ip>
+      <obj>/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
+      <fn>operator new[](unsigned long)</fn>
+      <dir>./coregrind/m_replacemalloc</dir>
+      <file>vg_replace_malloc.c</file>
+      <line>640</line>
+    </frame>
+    <frame>
+      <ip>0x109151</ip>
+      <obj>/home/some_user/terrible_program/terrible_program</obj>
+      <fn>main</fn>
+      <dir>/home/some_user/terrible_program</dir>
+      <file>terrible_program.cpp</file>
+      <line>3</line>
+    </frame>
+  </stack>
+  <suppression>
+    <sname>insert_a_suppression_name_here</sname>
+    <skind>Memcheck:Cond</skind>
+    <sframe> <fun>main</fun> </sframe>
+    <rawtext>
+<![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:main
+}
+]]>
+    </rawtext>
+  </suppression>
+</error>
+
+  <suppression>
+    <sname>insert_a_suppression_name_here</sname>
+    <skind>Memcheck:Cond</skind>
+    <sframe> <fun>main</fun> </sframe>
+    <rawtext>
+<![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:main
+}
+]]>
+    </rawtext>
+  </suppression>
+<error>
+  <unique>0x1</unique>
+  <tid>1</tid>
+  <kind>InvalidWrite</kind>
+  <what>Invalid write of size 4</what>
+  <stack>
+    <frame>
+      <ip>0x109177</ip>
+      <obj>/home/some_user/terrible_program/terrible_program</obj>
+      <fn>main</fn>
+      <dir>/home/some_user/terrible_program</dir>
+      <file>terrible_program.cpp</file>
+      <line>10</line>
+    </frame>
+  </stack>
+  <auxwhat>Address 0x4dd0c90 is 0 bytes after a block of size 16 alloc'd</auxwhat>
+  <stack>
+    <frame>
+      <ip>0x483B20F</ip>
+      <obj>/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
+      <fn>operator new[](unsigned long)</fn>
+      <dir>./coregrind/m_replacemalloc</dir>
+      <file>vg_replace_malloc.c</file>
+      <line>640</line>
+    </frame>
+    <frame>
+      <ip>0x109151</ip>
+      <obj>/home/some_user/terrible_program/terrible_program</obj>
+      <fn>main</fn>
+      <dir>/home/some_user/terrible_program</dir>
+      <file>terrible_program.cpp</file>
+      <line>3</line>
+    </frame>
+  </stack>
+  <suppression>
+    <sname>insert_a_suppression_name_here</sname>
+    <skind>Memcheck:Addr4</skind>
+    <sframe> <fun>main</fun> </sframe>
+    <rawtext>
+<![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr4
+   fun:main
+}
+]]>
+    </rawtext>
+  </suppression>
+</error>
+
+  <suppression>
+    <sname>insert_a_suppression_name_here</sname>
+    <skind>Memcheck:Addr4</skind>
+    <sframe> <fun>main</fun> </sframe>
+    <rawtext>
+<![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr4
+   fun:main
+}
+]]>
+    </rawtext>
+  </suppression>
+
+<status>
+  <state>FINISHED</state>
+  <time>00:00:00:00.693 </time>
+</status>
+
+<error>
+  <unique>0x2</unique>
+  <tid>1</tid>
+  <kind>Leak_DefinitelyLost</kind>
+  <xwhat>
+    <text>16 bytes in 1 blocks are definitely lost in loss record 1 of 1</text>
+    <leakedbytes>16</leakedbytes>
+    <leakedblocks>1</leakedblocks>
+  </xwhat>
+  <stack>
+    <frame>
+      <ip>0x483B20F</ip>
+      <obj>/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
+      <fn>operator new[](unsigned long)</fn>
+      <dir>./coregrind/m_replacemalloc</dir>
+      <file>vg_replace_malloc.c</file>
+      <line>640</line>
+    </frame>
+    <frame>
+      <ip>0x109151</ip>
+      <obj>/home/some_user/terrible_program/terrible_program</obj>
+      <fn>main</fn>
+      <dir>/home/some_user/terrible_program</dir>
+      <file>terrible_program.cpp</file>
+      <line>3</line>
+    </frame>
+  </stack>
+  <suppression>
+    <sname>insert_a_suppression_name_here</sname>
+    <skind>Memcheck:Leak</skind>
+    <skaux>match-leak-kinds: definite</skaux>
+    <sframe> <fun>_Znam</fun> </sframe>
+    <sframe> <fun>main</fun> </sframe>
+    <rawtext>
+<![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znam
+   fun:main
+}
+]]>
+    </rawtext>
+  </suppression>
+</error>
+
+  <suppression>
+    <sname>insert_a_suppression_name_here</sname>
+    <skind>Memcheck:Leak</skind>
+    <skaux>match-leak-kinds: definite</skaux>
+    <sframe> <fun>_Znam</fun> </sframe>
+    <sframe> <fun>main</fun> </sframe>
+    <rawtext>
+<![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znam
+   fun:main
+}
+]]>
+    </rawtext>
+  </suppression>
+<errorcounts>
+  <pair>
+    <count>1</count>
+    <unique>0x1</unique>
+  </pair>
+  <pair>
+    <count>1</count>
+    <unique>0x0</unique>
+  </pair>
+</errorcounts>
+
+<suppcounts>
+</suppcounts>
+
+</valgrindoutput>
+


### PR DESCRIPTION
Here's a parser for [valgrind](https://valgrind.org) XML reports.  I tried to match the style used elsewhere and make all the relevant information valgrind provides that wouldn't fit in the standard violation fields available in the specifics.