### PR TITLE
fix valgrind suppression parsing

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/parsers/ValgrindParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/ValgrindParser.java
@@ -290,11 +290,14 @@ public class ValgrindParser implements ViolationsParser {
                 frame.line = Integer.parseInt(xml.getText());
               }
               break;
-            case SUPPRESSION_RAWTEXT:
-              if (!xml.getText().isEmpty()) {
-                suppression = xml.getText().trim();
+            case SUPPRESSION_RAWTEXT: {
+              final String trimmedText = xml.getText().trim();
+
+              if (!trimmedText.isEmpty()) {
+                suppression = trimmedText;
               }
               break;
+            }
             default:
               break;
           }

--- a/src/test/java/se/bjurr/violations/lib/ValgrindTest.java
+++ b/src/test/java/se/bjurr/violations/lib/ValgrindTest.java
@@ -53,7 +53,7 @@ public class ValgrindTest {
                         "[[{\"ip\":\"0x109177\",\"obj\":\"/home/some_user/terrible_program/terrible_program\",\"fn\":\"main\",\"dir\":\"/home/some_user/terrible_program\",\"file\":\"terrible_program.cpp\",\"line\":10}]," //
                             + "[{\"ip\":\"0x483B20F\",\"obj\":\"/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so\",\"fn\":\"operator new[](unsigned long)\",\"dir\":\"./coregrind/m_replacemalloc\",\"file\":\"vg_replace_malloc.c\",\"line\":640}," //
                             + "{\"ip\":\"0x109151\",\"obj\":\"/home/some_user/terrible_program/terrible_program\",\"fn\":\"main\",\"dir\":\"/home/some_user/terrible_program\",\"file\":\"terrible_program.cpp\",\"line\":3}]]"); //
-                    this.put("suppression", "");
+                    this.put("suppression", "{\n   <insert_a_suppression_name_here>\n   Memcheck:Addr4\n   fun:main\n}");
                   }
                 }) //
             .build();
@@ -83,7 +83,7 @@ public class ValgrindTest {
                         "[[{\"ip\":\"0x109163\",\"obj\":\"/home/some_user/terrible_program/terrible_program\",\"fn\":\"main\",\"dir\":\"/home/some_user/terrible_program\",\"file\":\"terrible_program.cpp\",\"line\":5}]," //
                             + "[{\"ip\":\"0x483B20F\",\"obj\":\"/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so\",\"fn\":\"operator new[](unsigned long)\",\"dir\":\"./coregrind/m_replacemalloc\",\"file\":\"vg_replace_malloc.c\",\"line\":640}," //
                             + "{\"ip\":\"0x109151\",\"obj\":\"/home/some_user/terrible_program/terrible_program\",\"fn\":\"main\",\"dir\":\"/home/some_user/terrible_program\",\"file\":\"terrible_program.cpp\",\"line\":3}]]"); //
-                    this.put("suppression", "");
+                    this.put("suppression", "{\n   <insert_a_suppression_name_here>\n   Memcheck:Cond\n   fun:main\n}");
                   }
                 })
             .build();
@@ -108,7 +108,7 @@ public class ValgrindTest {
                         "stacks",
                         "[[{\"ip\":\"0x483B20F\",\"obj\":\"/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so\",\"fn\":\"operator new[](unsigned long)\",\"dir\":\"./coregrind/m_replacemalloc\",\"file\":\"vg_replace_malloc.c\",\"line\":640}," //
                             + "{\"ip\":\"0x109151\",\"obj\":\"/home/some_user/terrible_program/terrible_program\",\"fn\":\"main\",\"dir\":\"/home/some_user/terrible_program\",\"file\":\"terrible_program.cpp\",\"line\":3}]]"); //
-                    this.put("suppression", "");
+                    this.put("suppression", "{\n   <insert_a_suppression_name_here>\n   Memcheck:Leak\n   match-leak-kinds: definite\n   fun:_Znam\n   fun:main\n}");
                   }
                 }) //
             .build();


### PR DESCRIPTION
Here's a fix for the removal of Java 11 stuff from #138.  Looks like the switch from isBlank() to isEmpty() is what was breaking the `suppression` parsing.  The XML parser calls that thing 3 times for each suppression.  The 2nd time has the real CDATA content while the 1st and 3rd times have only whitespace, so the isBlank() was crucial to making it work right because the 3rd time would overwrite the actual suppression content with an empty string.  This update does the same thing as the original without requiring Java 11.  Sorry about that!