### PR TITLE
add paths to valgrind Violation.file

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/parsers/ValgrindParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/ValgrindParser.java
@@ -139,7 +139,7 @@ public class ValgrindParser implements ViolationsParser {
             if ((stacks != null) && !stacks.isEmpty()) {
               for (final StackFrame f : stacks.get(0)) {
                 if ((f.file != null) && !f.file.equals("vg_replace_malloc.c")) {
-                  file = f.file;
+                  file = (f.dir != null) ? f.dir + '/' + f.file : f.file;
                   startLine = f.line;
                   break;
                 }

--- a/src/test/java/se/bjurr/violations/lib/ValgrindTest.java
+++ b/src/test/java/se/bjurr/violations/lib/ValgrindTest.java
@@ -34,7 +34,7 @@ public class ValgrindTest {
             .setParser(VALGRIND) //
             .setReporter(MEMCHECK_REPORTER) //
             .setSource(SOURCE) //
-            .setFile("terrible_program.cpp") //
+            .setFile("/home/some_user/terrible_program/terrible_program.cpp") //
             .setStartLine(10) //
             .setEndLine(10) //
             .setRule("InvalidWrite") //
@@ -65,7 +65,7 @@ public class ValgrindTest {
             .setParser(VALGRIND) //
             .setReporter(MEMCHECK_REPORTER) //
             .setSource(SOURCE) //
-            .setFile("terrible_program.cpp") //
+            .setFile("/home/some_user/terrible_program/terrible_program.cpp") //
             .setStartLine(5) //
             .setEndLine(5) //
             .setRule("UninitCondition") //
@@ -97,7 +97,7 @@ public class ValgrindTest {
             .setParser(VALGRIND) //
             .setReporter(MEMCHECK_REPORTER) //
             .setSource(SOURCE) //
-            .setFile("terrible_program.cpp") //
+            .setFile("/home/some_user/terrible_program/terrible_program.cpp") //
             .setStartLine(3) //
             .setEndLine(3) //
             .setRule("Leak_DefinitelyLost") //


### PR DESCRIPTION
Looks like I messed up the file part of the valgrind Violation by only including the filename.  This pull request adds the path which seems to follow the pattern elsewhere.