### PR TITLE
Sarif Reporter Fix

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/parsers/SarifParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/SarifParser.java
@@ -58,6 +58,13 @@ public class SarifParser implements ViolationsParser {
       return violations;
     }
     for (final Run run : report.getRuns()) {
+      String reporter = "Sarif";
+      if (run.getTool() != null
+          && run.getTool().getDriver() != null
+          && run.getTool().getDriver().getName() != null
+          && !run.getTool().getDriver().getName().trim().isEmpty()) {
+        reporter = run.getTool().getDriver().getName();
+      }
       final List<Artifact> artifacts = new ArrayList<>(run.getArtifacts());
       for (final Result result : run.getResults()) {
         final String ruleId = result.getRuleId();
@@ -96,6 +103,7 @@ public class SarifParser implements ViolationsParser {
                   .setRule(ruleId)
                   .setMessage((message + " " + regionMessageText).trim())
                   .setSeverity(this.toSeverity(level))
+                  .setReporter(reporter)
                   .build());
         }
       }

--- a/src/test/java/se/bjurr/violations/lib/SarifParserTest.java
+++ b/src/test/java/se/bjurr/violations/lib/SarifParserTest.java
@@ -57,6 +57,7 @@ public class SarifParserTest {
         .isEqualTo(1);
     assertThat(first.getEndLine()) //
         .isEqualTo(1);
+    assertThat(first.getReporter()).isEqualTo("ESLint");
   }
 
   @Test
@@ -88,6 +89,7 @@ public class SarifParserTest {
         .isEqualTo(144);
     assertThat(first.getEndLine()) //
         .isEqualTo(144);
+    assertThat(first.getReporter()).isEqualTo("Polyspace");
   }
 
   @Test

--- a/src/test/resources/sarif/result_line_nr.json
+++ b/src/test/resources/sarif/result_line_nr.json
@@ -5,7 +5,7 @@
     {
       "tool": {
         "driver": {
-          "name": "Polyspace ",
+          "name": "Polyspace",
           "semanticVersion": "R2021b",
           "organization": "MathWorks",
           "rules": [


### PR DESCRIPTION
For the Sarif parser, as the reports could come from multiple tools, the driver name should be used as the reporter instead of `Sarif`. That way if Checkmarx outputs a Sarif report and Semgrep outputs a sarif report one can differentiate the findings when these are converted to violation comments in a PR.