### PR TITLE
Sarif Rule Help Text

### DIFF
--- a/src/test/java/se/bjurr/violations/lib/SarifParserTest.java
+++ b/src/test/java/se/bjurr/violations/lib/SarifParserTest.java
@@ -76,7 +76,7 @@ public class SarifParserTest {
     final Violation first = new ArrayList<>(actual).get(0);
     assertThat(first.getMessage()) //
         .isEqualTo(
-            "'unsigned char' doesn't provide information about its size. Define and use typedefs clarifying type and size for numerical types or use one of the exact-width numerical types defined in <stdint.h>.");
+            "'unsigned char' doesn't provide information about its size. Define and use typedefs clarifying type and size for numerical types or use one of the exact-width numerical types defined in <stdint.h>.\n\nFor additional help see: [How to resolve polyspace misra-c-2812](https://www.mathworks.com/matlabcentral/answers/479913-how-to-resolve-polyspace-misra-c-2012-d4-14-rule-when-am-passing-pointer-as-parameter-to-function)");
     assertThat(first.getFile()) //
         .isEqualTo(
             "file:/c:/var/lib/jenkins/workspace/PSBF_PIControl_DeclPipeline_Access/pi_alg/pi_alg.c");

--- a/src/test/resources/sarif/result_line_nr.json
+++ b/src/test/resources/sarif/result_line_nr.json
@@ -115,7 +115,11 @@
             },
             {
               "id": "MISRA C:2012 D4.6",
-              "name": "Dir 4.6 typedefs that indicate size and signedness should be used in place of the basic numerical types."
+              "name": "Dir 4.6 typedefs that indicate size and signedness should be used in place of the basic numerical types.",
+              "help": {
+                "text": "https://www.mathworks.com/matlabcentral/answers/479913-how-to-resolve-polyspace-misra-c-2012-d4-14-rule-when-am-passing-pointer-as-parameter-to-function",
+                "markdown": "[How to resolve polyspace misra-c-2812](https://www.mathworks.com/matlabcentral/answers/479913-how-to-resolve-polyspace-misra-c-2012-d4-14-rule-when-am-passing-pointer-as-parameter-to-function)"
+              }
             },
             {
               "id": "MISRA C:2012 8.4",


### PR DESCRIPTION
Adds support for help text from Sarif rules. Some SAST tools provide a help text/link within the rule. This PR adds support to append the help text to the message.