### PR TITLE
Favor Markdown from Sarif Reports

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/parsers/SarifParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/SarifParser.java
@@ -73,7 +73,7 @@ public class SarifParser implements ViolationsParser {
       for (final Result result : run.getResults()) {
 
         final String ruleId = result.getRuleId();
-        final String message = result.getMessage().getText();
+        final String message = extractMessage(result.getMessage());
         if (Utils.isNullOrEmpty(message)) {
           continue;
         }
@@ -117,6 +117,23 @@ public class SarifParser implements ViolationsParser {
       }
     }
     return violations;
+  }
+
+  /**
+   * Returns the message text - favoring the markdown format.
+   *
+   * @param message the message from the Sarif result.
+   * @return the message text which could be `null`.
+   */
+  protected String extractMessage(Message message) {
+    if (message == null) {
+      return null;
+    }
+    String text = message.getMarkdown();
+    if (Utils.isNullOrEmpty(text)) {
+      text = message.getText();
+    }
+    return text;
   }
 
   private Map<String, String> extractHelpText(Run run) {

--- a/src/main/java/se/bjurr/violations/lib/parsers/SarifParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/SarifParser.java
@@ -95,10 +95,10 @@ public class SarifParser implements ViolationsParser {
           } else {
             filename = physicalLocation.getArtifactLocation().getUri();
           }
-          final Message regionMessage = region.getMessage();
+          final String regionMessage = extractMessage(region.getMessage());
           StringBuilder fullMessage = new StringBuilder(message);
           if (regionMessage != null) {
-            fullMessage.append("\n\n").append(regionMessage.getText());
+            fullMessage.append("\n\n").append(regionMessage);
           }
           if (helpMap.containsKey(ruleId)) {
             fullMessage.append("\n\nFor additional help see: ").append(helpMap.get(ruleId));

--- a/src/test/java/se/bjurr/violations/lib/parsers/SarifParserTest.java
+++ b/src/test/java/se/bjurr/violations/lib/parsers/SarifParserTest.java
@@ -1,0 +1,28 @@
+package se.bjurr.violations.lib.parsers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import se.bjurr.violations.lib.model.generated.sarif.Message;
+
+public class SarifParserTest {
+
+  @Test
+  public void testExtractMessage() {
+    SarifParser instance = new SarifParser();
+    Message message = null;
+    String result = instance.extractMessage(message);
+    assertThat(result).isNull();
+
+    message = new Message();
+    message.setText("Plain text");
+    String expected = "Plain text";
+    result = instance.extractMessage(message);
+    assertThat(result).isEqualTo(expected);
+
+    message.setMarkdown("__Fancy text__");
+    expected = "__Fancy text__";
+    result = instance.extractMessage(message);
+    assertThat(result).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
When extracting the message text from both the result's message and region message the tool should favor the markdown formatted text. Many downstream destinations support markdown and for those that do not - it is still fully readable.