### PR TITLE
Fixes #153: Handle absolute Windows paths in ErrorProne warnings

### DIFF
--- a/src/main/java/se/bjurr/violations/lib/parsers/ValgrindParser.java
+++ b/src/main/java/se/bjurr/violations/lib/parsers/ValgrindParser.java
@@ -361,6 +361,5 @@ public class ValgrindParser implements ViolationsParser {
           + this.line
           + "]";
     }
-  }
-  ;
+  };
 }

--- a/src/main/java/se/bjurr/violations/lib/util/ViolationParserUtils.java
+++ b/src/main/java/se/bjurr/violations/lib/util/ViolationParserUtils.java
@@ -72,9 +72,7 @@ public final class ViolationParserUtils {
     return Arrays.asList(string.split("\n"));
   }
 
-  /**
-   * @return List per line in String, with groups from regexpPerLine.
-   */
+  /** @return List per line in String, with groups from regexpPerLine. */
   public static List<List<String>> getLines(final String string, final String regexpPerLine) {
     final List<List<String>> results = new ArrayList<>();
     final Pattern pattern = Pattern.compile(regexpPerLine);

--- a/src/test/java/se/bjurr/violations/lib/GoogleErrorProneTest.java
+++ b/src/test/java/se/bjurr/violations/lib/GoogleErrorProneTest.java
@@ -8,6 +8,7 @@ import static se.bjurr.violations.lib.model.SEVERITY.WARN;
 import static se.bjurr.violations.lib.reports.Parser.GOOGLEERRORPRONE;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Set;
 import org.junit.Test;
 import se.bjurr.violations.lib.model.Violation;
@@ -28,31 +29,55 @@ public class GoogleErrorProneTest {
     assertThat(actual) //
         .hasSize(5);
 
-    final Violation violation0 = new ArrayList<>(actual).get(0);
+    final Violation violation0 =
+        findViolation(
+            actual, //
+            "/home/bjerre/workspace/git-changelog/git-changelog-lib/src/main/java/se/bjurr/gitchangelog/internal/integrations/github/GitHubHelper.java", //
+            51);
     assertThat(violation0.getMessage()) //
         .endsWith("Splitter.on(\",\").split(link)) {'?");
-    assertThat(violation0.getFile()) //
-        .isEqualTo(
-            "/home/bjerre/workspace/git-changelog/git-changelog-lib/src/main/java/se/bjurr/gitchangelog/internal/integrations/github/GitHubHelper.java");
     assertThat(violation0.getSeverity()) //
         .isEqualTo(WARN);
     assertThat(violation0.getRule()) //
         .isEqualTo("StringSplitter");
-    assertThat(violation0.getStartLine()) //
-        .isEqualTo(51);
 
-    final Violation violation4 = new ArrayList<>(actual).get(3);
+    final Violation violation4 =
+        findViolation(
+            actual, //
+            "/home/bjerre/workspace/git-changelog/git-changelog-lib/src/main/java/se/bjurr/gitchangelog/internal/git/TraversalWork.java", //
+            73);
     assertThat(violation4.getMessage()) //
         .endsWith(", otherCommitTime);'?");
-    assertThat(violation4.getFile()) //
-        .isEqualTo(
-            "home/bjerre/workspace/git-changelog/git-changelog-lib/src/main/java/se/bjurr/gitchangelog/internal/git/TraversalWork.java");
     assertThat(violation4.getSeverity()) //
         .isEqualTo(WARN);
     assertThat(violation4.getRule()) //
         .isEqualTo("BoxedPrimitiveConstructor");
-    assertThat(violation4.getStartLine()) //
-        .isEqualTo(73);
+  }
+
+  /**
+   * Test fix for #153: When running ErrorProne from Gradle on Windows, errors are reported for
+   * absolute paths (e.g. {@code C:\\a\\b\\c.txt}).
+   */
+  @Test
+  public void testThatAbsoluteWindowsPathsAreRecognised() {
+    final Set<Violation> violations =
+        violationsApi() //
+            .withPattern(".*/googleErrorProne/errorprone-windows\\.log$") //
+            .inFolder(getRootFolder()) //
+            .findAll(GOOGLEERRORPRONE) //
+            .violations();
+
+    assertThat(violations) //
+        .hasSize(1);
+
+    Violation v = violations.iterator().next();
+    assertThat(v.getMessage()) //
+        .startsWith("returning @Nullable expression from method with @NonNull return type");
+    // Constructor of 'Violation' replaces all backslashes with forward slashes
+    assertThat(v.getFile()) //
+        .isEqualTo("C:/proj/src/main/java/Test.java");
+    assertThat(v.getStartLine()) //
+        .isEqualTo(12);
   }
 
   @Test
@@ -73,7 +98,7 @@ public class GoogleErrorProneTest {
     assertThat(violation0.getMessage()) //
         .endsWith("row new Exception();'?");
     assertThat(violation0.getFile()) //
-        .isEqualTo("../examples/maven/error_prone_should_flag/src/main/java/Main.java");
+        .isEqualTo(".../examples/maven/error_prone_should_flag/src/main/java/Main.java");
     assertThat(violation0.getSeverity()) //
         .isEqualTo(ERROR);
     assertThat(violation0.getRule()) //
@@ -101,12 +126,19 @@ public class GoogleErrorProneTest {
         .endsWith("nullaway )");
     assertThat(violation0.getFile()) //
         .isEqualTo(
-            "home/travis/build/leinardi/FloatingActionButtonSpeedDial/library/src/main/java/com/leinardi/android/speeddial/SpeedDialActionItem.java");
+            "/home/travis/build/leinardi/FloatingActionButtonSpeedDial/library/src/main/java/com/leinardi/android/speeddial/SpeedDialActionItem.java");
     assertThat(violation0.getSeverity()) //
         .isEqualTo(ERROR);
     assertThat(violation0.getRule()) //
         .isEqualTo("NullAway");
     assertThat(violation0.getStartLine()) //
         .isEqualTo(175);
+  }
+
+  private static Violation findViolation(Collection<Violation> violations, String file, int line) {
+    return violations.stream() //
+        .filter(v -> v.getFile().equals(file) && v.getStartLine() == line) //
+        .findFirst() //
+        .orElseThrow(() -> new AssertionError("Violation not found: " + file + ":" + line));
   }
 }

--- a/src/test/resources/googleErrorProne/errorprone-windows.log
+++ b/src/test/resources/googleErrorProne/errorprone-windows.log
@@ -1,0 +1,5 @@
+C:\proj\src\main\java\Test.java:12: warning: [NullAway] returning @Nullable expression from method with @NonNull return type
+            return null;
+            ^
+    (see http://t.uber.com/nullaway )
+1 warning

--- a/src/test/resources/googleErrorProne/googleErrorProne.log
+++ b/src/test/resources/googleErrorProne/googleErrorProne.log
@@ -1,6 +1,7 @@
 :googleErrorProne UP-TO-DATE
 :googleJavaFormat NO-SOURCE
-:compileJava/home/bjerre/workspace/git-changelog/git-changelog-lib/src/main/java/se/bjurr/gitchangelog/internal/integrations/github/GitHubHelper.java:51: warning: [StringSplitter] Prefer Splitter to String.split
+:compileJava
+/home/bjerre/workspace/git-changelog/git-changelog-lib/src/main/java/se/bjurr/gitchangelog/internal/integrations/github/GitHubHelper.java:51: warning: [StringSplitter] Prefer Splitter to String.split
           for (final String part : link.split(",")) {
                                              ^
     (see http://errorprone.info/bugpattern/StringSplitter)


### PR DESCRIPTION
Also fixes an issue where the first character of the file path was sometimes omitted.